### PR TITLE
No error in completion if ~/.aws/credentials and ~/.aws/config don't exist

### DIFF
--- a/conf.d/asp.fish
+++ b/conf.d/asp.fish
@@ -1,9 +1,13 @@
 function __fish_print_aws_profiles -d 'Prints a list of AWS profiles' -a select
   set -q AWS_CONFIG_FILE; or set AWS_CONFIG_FILE "$HOME/.aws/config"
-  set profiles (command sed -n 's/^\[profile \(.*\)\]/\1/p' "$AWS_CONFIG_FILE")
+  if test -f "$AWS_CONFIG_FILE"
+    set profiles (command sed -n 's/^\[profile \(.*\)\]/\1/p' "$AWS_CONFIG_FILE")
+  end
 
   set -q AWS_SHARED_CREDENTIALS_FILE; or set AWS_SHARED_CREDENTIALS_FILE "$HOME/.aws/credentials"
-  set credentials_profiles (command sed -n 's/^\[\(.*\)\]/\1/p' "$AWS_SHARED_CREDENTIALS_FILE")
+  if test -f "$AWS_SHARED_CREDENTIALS_FILE"
+    set credentials_profiles (command sed -n 's/^\[\(.*\)\]/\1/p' "$AWS_SHARED_CREDENTIALS_FILE")
+  end
 
   for profile in $credentials_profiles
     if not contains $profile $profiles


### PR DESCRIPTION
I don't have a ~/.aws/credentials file and got a sed error on completion. I modified this so no sed error if neither config nor credentials exist